### PR TITLE
When parsing, check the given src for being a URI

### DIFF
--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -23,14 +23,10 @@ class OpenGraph
   private
   def parse_opengraph(options = {})
     begin
-      if @src.include? '</html>'
-        @body = @src
-      else
-        @body = RedirectFollower.new(@src, options).resolve.body
-      end
+      uri = URI.parse(@src)
+      @body = RedirectFollower.new(@src, options).resolve.body
     rescue
-      @title = @url = @src
-      return
+      @body = @src
     end
 
     if @body

--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -23,7 +23,7 @@ class OpenGraph
   private
   def parse_opengraph(options = {})
     begin
-      uri = URI.parse(@src)
+      URI.parse(@src)
       @body = RedirectFollower.new(@src, options).resolve.body
     rescue
       @body = @src

--- a/spec/lib/open_graph_spec.rb
+++ b/spec/lib/open_graph_spec.rb
@@ -3,10 +3,10 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe OpenGraph do
   describe "#initialize" do
     context "with invalid src" do
-      it "should set title and url the same as src" do
+      it "should set the url to the same as src" do
         og = OpenGraph.new("invalid")
         og.src.should == "invalid"
-        og.title.should == "invalid"
+        og.title.should == nil
         og.url.should == "invalid"
       end
     end

--- a/spec/lib/open_graph_spec.rb
+++ b/spec/lib/open_graph_spec.rb
@@ -162,6 +162,19 @@ describe OpenGraph do
         og.description.should == "My OpenGraph sample site for Rspec"
         og.images.should == ["http://test.host/images/rock1.jpg", "http://test.host/images/rock2.jpg"]
       end
+
+      context 'the given src has no closing <html> tag' do
+        it 'assigns @body to @src and gets values from og metadata anyway' do
+          source = File.read("#{File.dirname(__FILE__)}/../view/opengraph_bad_html.html")
+          og = OpenGraph.new(source)
+          og.src.should == source
+          og.title.should == "OpenGraph Title"
+          og.type.should == "article"
+          og.url.should == "http://test.host"
+          og.description.should == "My bad OpenGraph sample site for Rspec"
+          og.images.should == ["http://test.host/images/bad_rock1.jpg"]
+        end
+      end
     end
   end
 end

--- a/spec/view/opengraph_bad_html.html
+++ b/spec/view/opengraph_bad_html.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <title>OpenGraph Title Fallback</title>
+    <meta property="og:title" content="OpenGraph Title" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="http://test.host" />
+    <meta property="og:description" content="My bad OpenGraph sample site for Rspec" />
+    <meta property="og:image" content="http://test.host/images/bad_rock1.jpg" />
+  </head>
+  <body>
+    <img src="http://test.host/images/wall1.jpg" />
+    <img src="http://test.host/images/wall2.jpg" />


### PR DESCRIPTION
Sometimes html doesn’t include `</html>`. In this case, the parsing
would blow up, even if it could pull image/description other og tags
from the html. Instead of checking for `</html>`, check for a valid URL
and fallback on trying to parse the html.